### PR TITLE
Updated nodejs version to LTS to avoid compatibility issues with npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM greatexpectations/great_expectations:python-3.7-buster-ge-0.12.0
 
-RUN apt-get update && apt-get install curl nodejs -y
+RUN apt-get update && apt-get install curl -y
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+RUN apt-get install -y nodejs
 RUN curl -L https://npmjs.org/install.sh | bash
 RUN npm install -g netlify-cli
 ENV NODE_PATH="/usr/lib/node_modules"


### PR DESCRIPTION
Fix for the below issue:
https://github.com/great-expectations/great_expectations_action/issues/79

Summary:
great_expectations_action build docker image is failing with incompatible Node.js version